### PR TITLE
refactor: renomeia propriedade cpf para documento na InscritoTurmaDTO da tela do codaf

### DIFF
--- a/src/core/services/codaf-lista-presenca-service.test.ts
+++ b/src/core/services/codaf-lista-presenca-service.test.ts
@@ -611,7 +611,7 @@ describe('CodafListaPresencaService', () => {
           items: [
             {
               id: 1,
-              cpf: '12345678900',
+              documento: '123.456.789-00',
               nome: 'João Silva',
               percentualFrequencia: 85,
               conceitoFinal: 'S',

--- a/src/core/services/codaf-lista-presenca-service.ts
+++ b/src/core/services/codaf-lista-presenca-service.ts
@@ -177,7 +177,7 @@ export const deletarRetificacao = (id: string | number): Promise<ApiResult<boole
 
 export type InscritoTurmaDTO = {
   id: number;
-  cpf: string;
+  documento: string;
   nome: string;
   percentualFrequencia: number;
   conceitoFinal: string;

--- a/src/pages/formacoes/lista-presenca-codaf/cadastro/index.tsx
+++ b/src/pages/formacoes/lista-presenca-codaf/cadastro/index.tsx
@@ -319,7 +319,7 @@ const CadastroListaPresencaCodaf: React.FC = () => {
       if (response.sucesso && response.dados) {
         const inscritosFormatados = response.dados.items.map((inscrito) => ({
           id: inscrito.id,
-          rfOuCpf: inscrito.cpf,
+          rfOuCpf: inscrito.documento,
           nomeCursista: inscrito.nome,
           frequencia: inscrito.percentualFrequencia ?? null,
           atividade:


### PR DESCRIPTION
Substituí o campo cpf por documento no DTO InscritoTurmaDTO e propaguei a alteração em toda a base de código. Atualizei o conjunto de testes para usar documento (formatado como CPF) e ajustei o componente CadastroListaPresencaCodaf para mapear rfOuCpf de inscrito.documento. [AB#143393](https://dev.azure.com/SME-Spassu/0b58ecd5-9e31-4506-a06c-32fdd13d5466/_workitems/edit/143393)