### PR TITLE
feat: Adicionar sigla à lista de coordenadores no seletor

### DIFF
--- a/src/pages/cadastros/area-promotora/list/index.tsx
+++ b/src/pages/cadastros/area-promotora/list/index.tsx
@@ -207,7 +207,7 @@ const ListAreaPromotora: React.FC = () => {
                 >
                   {listaCoordenadorias?.map((item) => (
                     <Option key={item.id} value={item.id}>
-                      {item.nome}
+                      {item.sigla ? `${item.sigla} - ${item.nome}` : item.nome}
                     </Option>
                   ))}
                   {loadingCoordenadorias && paginaCoordenadoria > 1 && (

--- a/src/pages/cadastros/coordenadoria/components/select-coordenadoria/select-coordenadoria.tsx
+++ b/src/pages/cadastros/coordenadoria/components/select-coordenadoria/select-coordenadoria.tsx
@@ -75,7 +75,7 @@ export const SelectCoordenadoria: React.FC<SelectCoordenadoriaProps> = ({ formIt
       >
         {items.map((item) => (
           <Option key={item.id} value={item.id}>
-            {item.nome}
+            {item.sigla ? `${item.sigla} - ${item.nome}` : item.nome}
           </Option>
         ))}
         {loading && page > 1 && (


### PR DESCRIPTION
Esta solicitação de pull atualiza a forma como os itens são exibidos nas listas suspensas dos componentes de seleção "Área Promotora" e "Coordenadoria". Agora, se um item tiver uma sigla, ela será exibida junto com o nome no formato "sigla - nome"; caso contrário, apenas o nome será exibido.

Melhorias na exibição das listas suspensas:

* O componente `ListAreaPromotora` foi atualizado para exibir tanto a sigla quanto o nome de cada opção, caso a sigla esteja presente.

* O componente `SelectCoordenadoria` foi atualizado para exibir tanto a sigla quanto o nome de cada opção, caso a sigla esteja presente.

[AB#146432](https://dev.azure.com/SME-Spassu/0b58ecd5-9e31-4506-a06c-32fdd13d5466/_workitems/edit/146432)